### PR TITLE
Make the Fomabin build work again

### DIFF
--- a/src/morphological-fst-rules.mk
+++ b/src/morphological-fst-rules.mk
@@ -60,10 +60,12 @@ crk-descriptive-analyzer.hfst: crk-orth.hfst crk-strict-analyzer.hfst
 	-@echo "$(_EMPH)Composing spelling relaxation transducer with normative analyzer transducer to create descriptive analyzer.$(_RESET)"
 	hfst-compose -F -1 $(word 1, $^) -2 $(word 2, $^) | hfst-minimize - -o $@
 
+crk-orth.foma: $(ORTHOGRAPHY)
+	(printf "regex"; cat $^ | sed 's/#.*$$//' | tr $$'\n' ' '; echo ; echo "invert" ) > $@
+
 # XXX: something is UP with the new spell relax, so manually compose the orthographic fst.
 crk-descriptive-analyzer.fomabin: crk-orth.fomabin crk-strict-analyzer.fomabin
 	foma -e "load $(word 1, $^)" \
-		-e "invert" \
 		-e "define Orthography;" \
 		-e "load $(word 2, $^)" \
 		-e "define NormativeAnalyzer;" \
@@ -74,3 +76,6 @@ crk-descriptive-analyzer.fomabin: crk-orth.fomabin crk-strict-analyzer.fomabin
 
 %.hfstol: %.hfst
 	hfst-fst2fst -O -i $< -o $@
+
+%.fomabin: %.foma
+	foma -l $< -e "save stack $@" -s

--- a/src/morphological-fst-rules.mk
+++ b/src/morphological-fst-rules.mk
@@ -60,5 +60,17 @@ crk-descriptive-analyzer.hfst: crk-orth.hfst crk-strict-analyzer.hfst
 	-@echo "$(_EMPH)Composing spelling relaxation transducer with normative analyzer transducer to create descriptive analyzer.$(_RESET)"
 	hfst-compose -F -1 $(word 1, $^) -2 $(word 2, $^) | hfst-minimize - -o $@
 
+# XXX: something is UP with the new spell relax, so manually compose the orthographic fst.
+crk-descriptive-analyzer.fomabin: crk-orth.fomabin crk-strict-analyzer.fomabin
+	foma -e "load $(word 1, $^)" \
+		-e "invert" \
+		-e "define Orthography;" \
+		-e "load $(word 2, $^)" \
+		-e "define NormativeAnalyzer;" \
+		-e "regex Orthography .o. NormativeAnalyzer;" \
+		-e "minimize" \
+		-e "save stack $@" \
+		-s
+
 %.hfstol: %.hfst
 	hfst-fst2fst -O -i $< -o $@

--- a/src/morphological-fst-rules.mk
+++ b/src/morphological-fst-rules.mk
@@ -60,15 +60,13 @@ crk-descriptive-analyzer.hfst: crk-orth.hfst crk-strict-analyzer.hfst
 	-@echo "$(_EMPH)Composing spelling relaxation transducer with normative analyzer transducer to create descriptive analyzer.$(_RESET)"
 	hfst-compose -F -1 $(word 1, $^) -2 $(word 2, $^) | hfst-minimize - -o $@
 
-crk-orth.foma: $(ORTHOGRAPHY)
-	(printf "regex"; cat $^ | sed 's/#.*$$//' | tr $$'\n' ' '; echo ; echo "invert" ) > $@
-
 # XXX: something is UP with the new spell relax, so manually compose the orthographic fst.
 crk-descriptive-analyzer.fomabin: crk-orth.fomabin crk-strict-analyzer.fomabin
 	foma -e "load $(word 1, $^)" \
 		-e "define Orthography;" \
 		-e "load $(word 2, $^)" \
 		-e "define NormativeAnalyzer;" \
+		-e "set flag-is-epsilon ON" \
 		-e "regex Orthography .o. NormativeAnalyzer;" \
 		-e "minimize" \
 		-e "save stack $@" \
@@ -76,6 +74,3 @@ crk-descriptive-analyzer.fomabin: crk-orth.fomabin crk-strict-analyzer.fomabin
 
 %.hfstol: %.hfst
 	hfst-fst2fst -O -i $< -o $@
-
-%.fomabin: %.foma
-	foma -l $< -e "save stack $@" -s

--- a/src/morphological-fst-rules.mk
+++ b/src/morphological-fst-rules.mk
@@ -60,17 +60,5 @@ crk-descriptive-analyzer.hfst: crk-orth.hfst crk-strict-analyzer.hfst
 	-@echo "$(_EMPH)Composing spelling relaxation transducer with normative analyzer transducer to create descriptive analyzer.$(_RESET)"
 	hfst-compose -F -1 $(word 1, $^) -2 $(word 2, $^) | hfst-minimize - -o $@
 
-# XXX: something is UP with the new spell relax, so manually compose the orthographic fst.
-crk-descriptive-analyzer.fomabin: crk-orth.fomabin crk-strict-analyzer.fomabin
-	foma -e "load $(word 1, $^)" \
-		-e "define Orthography;" \
-		-e "load $(word 2, $^)" \
-		-e "define NormativeAnalyzer;" \
-		-e "set flag-is-epsilon ON" \
-		-e "regex Orthography .o. NormativeAnalyzer;" \
-		-e "minimize" \
-		-e "save stack $@" \
-		-s
-
 %.hfstol: %.hfst
 	hfst-fst2fst -O -i $< -o $@

--- a/src/orthography/spellrelax.regex
+++ b/src/orthography/spellrelax.regex
@@ -76,8 +76,8 @@ c (->) {ch},        # English influence on spelling <c>
 c (->) {tch},       # English influence on spelling <c>
 c (->) {ts} || _ ,, # Another English influence on spelling <c>
 
-[..] (->) h || [ a | i | o | â | ê | î | ô ] _ [ c | k | p | t ],,  # Excessive preaspiration before stops
-   h (->) 0 || [ a | i | o | â | ê | î | ô ] _ [ c | k | p | t ]    # Missing preaspiration before stops
+# TODO: create a rule for excessive preaspiration after stops
+h (->) 0 || [ a | i | o | â | ê | î | ô ] _ [ c | k | p | t ]    # Missing preaspiration before stops
 
 
 ;


### PR DESCRIPTION
For some reason, Foma really couldn't deal with one of these rules. In the commit history, there's the story of how I tried to fix this. Ultimately, I just deleted the one rule from the spell relax.

Closes #14 